### PR TITLE
Write objects with flan

### DIFF
--- a/source/adios2/toolkit/transport/file/FileFlexNVMe.cpp
+++ b/source/adios2/toolkit/transport/file/FileFlexNVMe.cpp
@@ -143,9 +143,9 @@ void FileFlexNVMe::Write(const char *buffer, size_t size, size_t start)
 
     std::string objectName = CreateChunkName();
 
-    uint64_t obj_handle = OpenFlanObject(objectName);
+    uint64_t objectHandle = OpenFlanObject(objectName);
 
-    if (flan_object_write(obj_handle,
+    if (flan_object_write(objectHandle,
                           static_cast<void *>(const_cast<char *>(buffer)), 0,
                           size, FileFlexNVMe::flanh))
     {
@@ -209,15 +209,15 @@ std::string FileFlexNVMe::CreateChunkName()
 
 auto FileFlexNVMe::OpenFlanObject(std::string &objectName) -> uint64_t
 {
-    uint64_t obj_handle = 0;
-    if (flan_object_open(objectName.c_str(), FileFlexNVMe::flanh, &obj_handle,
+    uint64_t objectHandle = 0;
+    if (flan_object_open(objectName.c_str(), FileFlexNVMe::flanh, &objectHandle,
                          FLAN_OPEN_FLAG_CREATE | FLAN_OPEN_FLAG_WRITE))
     {
         helper::Throw<std::ios_base::failure>(
             "Toolkit", "transport::file::FileFlexNVMe", "Write",
             "Failed to open object " + objectName);
     }
-    return obj_handle;
+    return objectHandle;
 }
 
 } // end namespace transport

--- a/source/adios2/toolkit/transport/file/FileFlexNVMe.cpp
+++ b/source/adios2/toolkit/transport/file/FileFlexNVMe.cpp
@@ -116,6 +116,10 @@ void FileFlexNVMe::OpenChain(const std::string &name, Mode openMode,
     m_baseName = name;
 }
 
+// TODO(adbo):
+//   - Set chunk size via parameters or make them static, because
+//     currently they are not shared across transport instances
+//   - Use the start parameter?
 void FileFlexNVMe::Write(const char *buffer, size_t size, size_t start)
 {
     // Set the chunk size since it's not been set before.

--- a/source/adios2/toolkit/transport/file/FileFlexNVMe.h
+++ b/source/adios2/toolkit/transport/file/FileFlexNVMe.h
@@ -11,6 +11,7 @@
 #ifndef ADIOS2_TOOLKIT_TRANSPORT_FILE_FLEXNVME_H_
 #define ADIOS2_TOOLKIT_TRANSPORT_FILE_FLEXNVME_H_
 
+#include <cstdint>
 #include <future> //std::async, std::future
 
 #include "adios2/common/ADIOSConfig.h"
@@ -84,7 +85,9 @@ private:
     std::string m_baseName = "";
 
     auto ErrnoErrMsg() const -> std::string;
+
     void InitFlan(const std::string &name);
+    auto OpenFlanObject(std::string &objectName) -> uint64_t;
 };
 
 } // end namespace transport


### PR DESCRIPTION
Very short addition due to #3 which takes care of bounds checks and object naming.

I'm not too thriled about `static_cast<void *>(const_cast<char *>` either..